### PR TITLE
Update workflow for FinaleToolkit 1.0.0 CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ output/
 supplement/
 tmp/
 snakemake.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A Snakemake workflow that automates cell-free DNA fragmentation feature extracti
 [FinaleToolkit](https://github.com/epifluidlab/FinaleToolkit) — supporting **hg38** and
 **T2T-CHM13**, parallel processing, SLURM, and BED/BAM/CRAM inputs.
 
+[![Docs](https://img.shields.io/badge/docs-epifluidlab.github.io-836eaa?style=flat-square)](https://epifluidlab.github.io/FinaleToolkit/documentation/workflow/)
+
 ### Contents
 
 |     Installation     |     Reference Setup     |     Usage     |     Parameters     |
@@ -122,8 +124,9 @@ Blacklist, BEDbase) by `setup_reference.sh`.
   FinaleToolkit command.
 * **Commands:** enable a FinaleToolkit command with underscores instead of hyphens (e.g. `adjust-wps`
   → `adjust_wps: True`); set flags by appending `_<flag>` (e.g. `coverage_mapq: 30`). The workflow
-  respects command dependencies (e.g. `mds` needs `end_motifs`). See [`params.yaml`](./params.yaml) for
-  the fully annotated list of every option.
+  respects command dependencies (e.g. `mds` needs `end_motifs`, `regional_mds` needs
+  `interval_end_motifs`). The per-region motif-diversity step is `regional_mds`. See
+  [`params.yaml`](./params.yaml) for the fully annotated list of every option.
 
 ### Output file naming
 
@@ -134,7 +137,7 @@ Blacklist, BEDbase) by `setup_reference.sh`.
 ### Citation
 Li JW, Bandaru R, Baliga K, Liu Y (2025). *FinaleToolkit: accelerating cell-free DNA fragmentation
 analysis with a high-speed computational toolkit.* **Bioinformatics Advances**.
-![DOI](https://img.shields.io/badge/DOI-10.1093%2Fbioadv%2Fvbaf236-DDC7A6?style=flat-square)
+[![DOI](https://img.shields.io/badge/DOI-10.1093%2Fbioadv%2Fvbaf236-836eaa?style=flat-square)](https://doi.org/10.1093/bioadv/vbaf236)
 
 ### Contact
 - Ravi Bandaru: ravi.bandaru@northwestern.edu

--- a/Snakefile
+++ b/Snakefile
@@ -50,7 +50,7 @@ coverage_dir                   = os.path.join(out_dir, "coverage")
 end_motifs_dir                 = os.path.join(out_dir, "end_motifs")
 interval_end_motifs_dir        = os.path.join(out_dir, "interval_end_motifs")
 mds_dir                        = os.path.join(out_dir, "mds")
-interval_mds_dir               = os.path.join(out_dir, "interval_mds")
+regional_mds_dir               = os.path.join(out_dir, "regional_mds")
 wps_dir                        = os.path.join(out_dir, "wps")
 adjust_wps_dir                 = os.path.join(out_dir, "adjust_wps")
 delfi_dir                      = os.path.join(out_dir, "delfi")
@@ -66,7 +66,7 @@ coverage = config.get("coverage", False)
 end_motifs = config.get("end_motifs", False)
 interval_end_motifs = config.get("interval_end_motifs", False)
 mds = config.get("mds", False)
-interval_mds = config.get("interval_mds", False)
+regional_mds = config.get("regional_mds", False)
 wps = config.get("wps", False)
 adjust_wps = config.get("adjust_wps", False)
 delfi = config.get("delfi", False)
@@ -81,8 +81,8 @@ if (adjust_wps and not wps):
 if (mds and not end_motifs):
     raise SystemExit("end-motifs is required to run mds.")
 
-if (interval_mds and not interval_end_motifs):
-    raise SystemExit("interval-end-motifs is required to run interval-mds.")
+if (regional_mds and not interval_end_motifs):
+    raise SystemExit("interval-end-motifs is required to run regional-mds.")
 
 if (file_format != "bam" and file_format != "cram" and file_format != "bed.gz" and file_format != "frag.gz"):
     raise SystemExit('File format must be of type "bed.gz," "bam," or "cram."')
@@ -94,7 +94,7 @@ elif file_format == "cram":
 elif file_format == "bed.gz" or file_format == "frag.gz":
     index = "tbi"
 
-using_finaletoolkit = frag_length_bins or frag_length_intervals or coverage or end_motifs or interval_end_motifs or mds or interval_mds or wps or adjust_wps or delfi or cleavage_profile or agg_bw or breakpoint_motifs or interval_breakpoint_motifs
+using_finaletoolkit = frag_length_bins or frag_length_intervals or coverage or end_motifs or interval_end_motifs or mds or regional_mds or wps or adjust_wps or delfi or cleavage_profile or agg_bw or breakpoint_motifs or interval_breakpoint_motifs
 
 # Set the expand function for the files.
 def io(endings, samples, condition, dir=out_dir):
@@ -128,7 +128,7 @@ rule all:
             io(["end_motifs.tsv"], value, end_motifs, end_motifs_dir) +
             io(["interval_end_motifs.tsv"], value, interval_end_motifs, interval_end_motifs_dir) +
             io(["mds.txt"], value, mds, mds_dir) +
-            io(["interval_mds.tsv"], value, interval_mds, interval_mds_dir) +
+            io(["regional_mds.tsv"], value, regional_mds, regional_mds_dir) +
             io(["wps.bw"], value, wps, wps_dir) +
             io(["adjust_wps.bw"], value, adjust_wps, adjust_wps_dir) +
             io(["delfi.bed"], value, delfi, delfi_dir) +
@@ -159,10 +159,10 @@ rule filter_file:
     run:
         if filter_file:
             command = f"""finaletoolkit filter-file \
-                {f" -W {params.filter_file_whitelist}" if params.filter_file_whitelist else ""} \
-                {f" -B {params.filter_file_blacklist}" if params.filter_file_blacklist else ""} \
-                -o {output.main} -q {params.filter_file_mapq} -min {params.filter_file_min_length} -max {params.filter_file_max_length} \
-                -p {params.filter_file_intersect_policy} -w {params.filter_file_workers} {input.main}"""
+                {f" -w {params.filter_file_whitelist}" if params.filter_file_whitelist else ""} \
+                {f" -b {params.filter_file_blacklist}" if params.filter_file_blacklist else ""} \
+                -o {output.main} -q {params.filter_file_mapq} --min-length {params.filter_file_min_length} --max-length {params.filter_file_max_length} \
+                -p {params.filter_file_intersect_policy} -t {params.filter_file_workers} {input.main}"""
             shell(command)
         else:
             shell(f"cp {input.main} {output.main}")
@@ -189,6 +189,7 @@ rule frag_length_bins:
         png=os.path.join(frag_length_bins_dir, "{sample}.frag_length_bins.png")
     threads: 1
     params:
+        reference = config.get("frag_length_bins_reference"),
         mapq = config.get("frag_length_bins_mapq"),
         bin_size = config.get("frag_length_bins_bin_size"),
         policy = config.get("frag_length_bins_policy"),
@@ -201,6 +202,8 @@ rule frag_length_bins:
         short_fraction = config.get("frag_length_bins_short_fraction")
     run:
         command_parts = [f"finaletoolkit frag-length-bins {input}"]
+        if params.reference is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference)}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.bin_size is not None:
@@ -208,9 +211,9 @@ rule frag_length_bins:
         if params.policy is not None:
             command_parts.append(f"-p {params.policy}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.chrom is not None and params.chrom != "":
             command_parts.append(f"-c {params.chrom}")
         if params.start is not None:
@@ -218,11 +221,11 @@ rule frag_length_bins:
         if params.end is not None:
             command_parts.append(f"-E {params.end}")
         if params.summary_stats:
-            command_parts.append("-stats")
+            command_parts.append("--summary-stats")
             if params.short_fraction is not None:
-                command_parts.append(f"-sf {params.short_fraction}")
+                command_parts.append(f"--short-threshold {params.short_fraction}")
         command_parts.append(f"-o {output.tsv}")
-        command_parts.append(f"--histogram-path {output.png} -v")
+        command_parts.append(f"--histogram {output.png} -v")
         command = " ".join(command_parts)
         print("Running: ", command)
         shell(f"{command}")
@@ -235,6 +238,7 @@ rule frag_length_intervals:
         os.path.join(frag_length_intervals_dir, "{sample}.frag_length_intervals.bed")
     threads: config.get("frag_length_intervals_workers")
     params:
+        reference = config.get("frag_length_intervals_reference"),
         min_len = config.get("frag_length_intervals_min_len"),
         max_len = config.get("frag_length_intervals_max_len"),
         policy = config.get("frag_length_intervals_policy"),
@@ -249,18 +253,20 @@ rule frag_length_intervals:
             input.intervals,
         ]
 
+        if params.reference is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference)}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.policy is not None:
             command_parts.append(f"-p {params.policy}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         if params.short_reads is not None:
-            command_parts.append(f"-s {params.short_reads}")
+            command_parts.append(f"--short-threshold {params.short_reads}")
 
         command_parts.append(f"-o {output[0]} -v")  # Ensure output indexing
 
@@ -277,6 +283,7 @@ rule coverage:
         os.path.join(coverage_dir, "{sample}.coverage.bed")
     threads: config.get("coverage_workers")
     params:
+        reference = config.get("coverage_reference"),
         min_len = config.get("coverage_min_len"),
         max_len = config.get("coverage_max_len"),
         normalize = config.get("coverage_normalize", False),
@@ -292,15 +299,17 @@ rule coverage:
             input.intervals,
         ]
 
+        if params.reference is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference)}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
         if params.normalize:
             command_parts.append("-n")
             if params.scale_factor is not None:
-                command_parts.append(f"-s {params.scale_factor}")
+                command_parts.append(f"--scale-factor {params.scale_factor}")
 
         if params.intersect_policy is not None:
             command_parts.append(f"-p {params.intersect_policy}")
@@ -309,7 +318,7 @@ rule coverage:
             command_parts.append(f"-q {params.mapq}")
 
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
 
         command_parts.append(f"-o {output} -v")
 
@@ -328,8 +337,7 @@ rule end_motifs:
         kmer_length = config.get("end_motifs_kmer_length"),
         min_len = config.get("end_motifs_min_len"),
         max_len = config.get("end_motifs_max_len"),
-        single_strand = config.get("end_motifs_single_strand", False),
-        negative_strand = config.get("end_motifs_negative_strand", False),
+        strand = config.get("end_motifs_strand"),
         mapq = config.get("end_motifs_mapq"),
         workers = config.get("end_motifs_workers")
     run:
@@ -343,19 +351,17 @@ rule end_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None:
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         command_parts.append(f"-o {output} -v")
 
         command = " ".join(command_parts)
@@ -374,8 +380,7 @@ rule interval_end_motifs:
         kmer_length = config.get("interval_end_motifs_kmer_length"),
         min_len = config.get("interval_end_motifs_min_len"),
         max_len = config.get("interval_end_motifs_max_len"),
-        single_strand = config.get("interval_end_motifs_single_strand", False),
-        negative_strand = config.get("interval_end_motifs_negative_strand", False),
+        strand = config.get("interval_end_motifs_strand"),
         mapq = config.get("interval_end_motifs_mapq"),
         workers = config.get("interval_end_motifs_workers")
     run:
@@ -390,19 +395,17 @@ rule interval_end_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None:
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         command_parts.append(f"-o {output[0]} -v")
 
         command = " ".join(command_parts)
@@ -435,18 +438,18 @@ rule mds:
         print("Running: ", command)
         shell(f"{command}")
 
-rule interval_mds:
+rule regional_mds:
     input:
         os.path.join(interval_end_motifs_dir, "{sample}.interval_end_motifs.tsv")
     output:
-        os.path.join(interval_mds_dir, "{sample}.interval_mds.tsv")
+        os.path.join(regional_mds_dir, "{sample}.regional_mds.tsv")
     params:
-        sep = config.get("interval_mds_sep", " "),
-        header = config.get("interval_mds_header")
+        sep = config.get("regional_mds_sep", " "),
+        header = config.get("regional_mds_header")
     run:
         command_parts = [
             "finaletoolkit",
-            "interval-mds"
+            "regional-mds"
         ]
         if params.sep is not None and not params.sep.isspace():
             command_parts.append(f"-s {params.sep}")
@@ -469,6 +472,7 @@ rule wps:
         os.path.join(wps_dir, "{sample}.wps.bw")
     threads: config.get("wps_workers")
     params:
+        reference = config.get("wps_reference"),
         chrom_sizes = config.get("wps_chrom_sizes"),
         interval_size = config.get("wps_interval_size"),
         window_size = config.get("wps_window_size"),
@@ -482,20 +486,22 @@ rule wps:
         time_min = config.get("wps_time_min", 1440)
     run:
         command_parts = ["finaletoolkit", "wps", input.data, input.site_bed]
+        if params.reference is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference)}")
         if params.chrom_sizes is not None:
-            command_parts.append(f"-c {os.path.join(sup_dir, params.chrom_sizes)}")
+            command_parts.append(f"--chrom-sizes {os.path.join(sup_dir, params.chrom_sizes)}")
         if params.interval_size is not None:
             command_parts.append(f"-i {params.interval_size}")
         if params.window_size is not None:
             command_parts.append(f"-W {params.window_size}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         command_parts.append(f"-o {output[0]} -v")
         command = " ".join(command_parts)
         print("Running: ", command)
@@ -514,7 +520,7 @@ rule adjust_wps:
         median_window_size = config.get("adjust_wps_median_window_size"),
         savgol_window_size = config.get("adjust_wps_savgol_window_size"),
         savgol_poly_deg = config.get("adjust_wps_savgol_poly_deg"),
-        exclude_savgol = config.get("adjust_wps_exclude_savgol", False),
+        savgol = config.get("adjust_wps_savgol", True),
         workers = config.get("adjust_wps_workers"),
         mean = config.get("adjust_wps_mean", False),
         subtract_edges = config.get("adjust_wps_subtract_edges", False),
@@ -533,13 +539,13 @@ rule adjust_wps:
         if params.median_window_size is not None:
             command_parts.append(f"-m {params.median_window_size}")
         if params.savgol_window_size is not None:
-            command_parts.append(f"-s {params.savgol_window_size}")
+            command_parts.append(f"--savgol-window-size {params.savgol_window_size}")
         if params.savgol_poly_deg is not None:
-            command_parts.append(f"-p {params.savgol_poly_deg}")
-        if params.exclude_savgol:
-            command_parts.append("-S")
+            command_parts.append(f"--savgol-poly-deg {params.savgol_poly_deg}")
+        if not params.savgol:
+            command_parts.append("--no-savgol")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         if params.mean:
             command_parts.append("--mean")
         if params.subtract_edges:
@@ -565,9 +571,9 @@ rule delfi:
         gap_file = config.get("delfi_gap_file"),
         gap_reference_genome = config.get("delfi_gap_reference_genome"),
         no_gc_correct = config.get("delfi_no_gc_correct", False),
-        keep_nocov = config.get("delfi_keep_nocov", False),
-        no_merge_bins = config.get("delfi_no_merge_bins", False),
-        window_size = config.get("delfi_window_size"),
+        remove_nocov = config.get("delfi_remove_nocov", True),
+        merge_bins = config.get("delfi_merge_bins", True),
+        merge_size = config.get("delfi_merge_size"),
         mapq = config.get("delfi_mapq"),
         workers = config.get("delfi_workers")
     run:
@@ -595,17 +601,17 @@ rule delfi:
         # file IS used, every contig in delfi_chrom_sizes must have a centromere entry.
 
         if params.no_gc_correct:
-            command_parts.append("-G")
-        if params.keep_nocov:
-            command_parts.append("-R")
-        if params.no_merge_bins:
-            command_parts.append("-M")
-        if params.window_size is not None:
-            command_parts.append(f"-s {params.window_size}")
+            command_parts.append("--no-gc-correct")
+        if not params.remove_nocov:
+            command_parts.append("--no-remove-nocov")
+        if not params.merge_bins:
+            command_parts.append("--no-merge-bins")
+        if params.merge_size is not None:
+            command_parts.append(f"--merge-size {params.merge_size}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
 
         command_parts.append(f"-o {output[0]} -v")
 
@@ -622,6 +628,7 @@ rule cleavage_profile:
         os.path.join(cleavage_profile_dir, "{sample}.cleavage_profile.bw")
     threads: config.get("cleavage_profile_workers")
     params:
+        reference = config.get("cleavage_profile_reference"),
         min_len = config.get("cleavage_profile_min_len"),
         max_len = config.get("cleavage_profile_max_len"),
         mapq = config.get("cleavage_profile_mapq"),
@@ -637,18 +644,20 @@ rule cleavage_profile:
             input.chrom_sizes,
         ]
 
+        if params.reference is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference)}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.left is not None:
-            command_parts.append(f"-l {params.left}")
+            command_parts.append(f"--pad-left {params.left}")
         if params.right is not None:
-            command_parts.append(f"-r {params.right}")
+            command_parts.append(f"--pad-right {params.right}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
 
         command_parts.append(f"-o {output[0]} -v")
         command = " ".join(command_parts)
@@ -676,7 +685,7 @@ rule agg_bw:
         if params.median_window_size is not None:
             command_parts.append(f"-m {params.median_window_size}")
         if params.mean:
-            command_parts.append("-a")
+            command_parts.append("--mean")
 
         command_parts.append(f"-o {output[0]}")
         command_parts.append("-v")
@@ -696,8 +705,7 @@ rule breakpoint_motifs:
         kmer_length = config.get("breakpoint_motifs_kmer_length"),
         min_len = config.get("breakpoint_motifs_min_len"),
         max_len = config.get("breakpoint_motifs_max_len"),
-        single_strand = config.get("breakpoint_motifs_single_strand", False),
-        negative_strand = config.get("breakpoint_motifs_negative_strand", False),
+        strand = config.get("breakpoint_motifs_strand"),
         mapq = config.get("breakpoint_motifs_mapq"),
         workers = config.get("breakpoint_motifs_workers")
     run:
@@ -711,19 +719,17 @@ rule breakpoint_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None:
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         command_parts.append(f"-o {output} -v")
 
         command = " ".join(command_parts)
@@ -742,8 +748,7 @@ rule interval_breakpoint_motifs:
         kmer_length = config.get("interval_breakpoint_motifs_kmer_length"),
         min_len = config.get("interval_breakpoint_motifs_min_len"),
         max_len = config.get("interval_breakpoint_motifs_max_len"),
-        single_strand = config.get("interval_breakpoint_motifs_single_strand", False),
-        negative_strand = config.get("interval_breakpoint_motifs_negative_strand", False),
+        strand = config.get("interval_breakpoint_motifs_strand"),
         mapq = config.get("interval_breakpoint_motifs_mapq"),
         workers = config.get("interval_breakpoint_motifs_workers")
     run:
@@ -758,19 +763,17 @@ rule interval_breakpoint_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None:
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"-t {params.workers}")
         command_parts.append(f"-o {output[0]} -v")
 
         command = " ".join(command_parts)

--- a/environment.yml
+++ b/environment.yml
@@ -11,11 +11,9 @@ dependencies:
   - samtools=1.21
   - openjdk=21
   - parallel
-  - "numpy<2.0"
   - snakemake-executor-plugin-slurm=2.7.1
   - pip
   - pip:
+    # FinaleToolkit pulls in its own numpy (>=2), pysam, and pyBigWig.
     - finaletoolkit
     - snakemake==8.27.1
-    - pybigwig==0.3.23 
-    - pysam==0.22.1

--- a/params.hg38.yaml
+++ b/params.hg38.yaml
@@ -59,10 +59,10 @@ interval_end_motifs_refseq_file: "hg38.2bit"
 interval_end_motifs_kmer_length: 4
 interval_end_motifs_min_len: 50
 interval_end_motifs_max_len: 350
-interval_end_motifs_single_strand: False
+interval_end_motifs_strand: both
 interval_end_motifs_mapq: 30
 interval_end_motifs_workers: 4
-interval_mds: True
+regional_mds: True
 
 # --- DELFI (500 kb bins, GC-corrected) ---
 delfi: True
@@ -72,8 +72,8 @@ delfi_bins_file: "hg38.500kb.bins.filtered"
 delfi_gap_file: "hg38.gap.bed"                # BED4 centromere/telomere annotations (finaletoolkit gap-bed)
 delfi_blacklist_file: "hg38.blacklist.bed"
 delfi_no_gc_correct: False
-delfi_keep_nocov: True
-delfi_no_merge_bins: True
-delfi_window_size: 5000000
+delfi_remove_nocov: False
+delfi_merge_bins: False
+delfi_merge_size: 5000000
 delfi_mapq: 30
 delfi_workers: 4

--- a/params.t2t-chm13.yaml
+++ b/params.t2t-chm13.yaml
@@ -59,10 +59,10 @@ interval_end_motifs_refseq_file: "chm13.2bit"
 interval_end_motifs_kmer_length: 4
 interval_end_motifs_min_len: 50
 interval_end_motifs_max_len: 350
-interval_end_motifs_single_strand: False
+interval_end_motifs_strand: both
 interval_end_motifs_mapq: 30
 interval_end_motifs_workers: 4
-interval_mds: True
+regional_mds: True
 
 # --- DELFI (500 kb bins, GC-corrected) ---
 delfi: True
@@ -73,8 +73,8 @@ delfi_bins_file: "chm13.500kb.bins.filtered"
 # without centromere masking (mappability + blacklist already exclude those regions).
 delfi_blacklist_file: "chm13.blacklist.bed"
 delfi_no_gc_correct: False
-delfi_keep_nocov: True
-delfi_no_merge_bins: True
-delfi_window_size: 5000000
+delfi_remove_nocov: False
+delfi_merge_bins: False
+delfi_merge_size: 5000000
 delfi_mapq: 30
 delfi_workers: 4

--- a/params.yaml
+++ b/params.yaml
@@ -1,128 +1,169 @@
-# Below is a sample configuration for extracting coverage features
+# Annotated example configuration. Every option below maps 1:1 to a FinaleToolkit
+# CLI option of the same command. Enable a command with `<command>: True`, then set
+# any of its options with `<command>_<option>`. Uncomment what you need.
+#
+# Files named below (references, blacklists, chrom.sizes, bins, refseq, sites) are
+# looked up in `supplement_dir`. `-r/--reference` is a FASTA, only needed for CRAM
+# input.
 
 # input_dir: "input_data"
 # output_dir: "output_data"
-# supplement_dir: "supplement" 
+# supplement_dir: "supplement"
 # interval_file: "intervals.bins"
-# file_format: "bed.gz"
+# file_format: "bed.gz"          # bed.gz | frag.gz | bam | cram
+# workers: 1                     # global default worker count
 
-# Finaletoolkit filter-file parameters
-
-# filter_file: True
-# filter_file_mapq: 30
-# filter_file_min_length: 50
-# filter_file_max_length: 350
-# filter_file_blacklist_file: "blacklist.bed"
-# filter_file_whitelist_file: "whitelist.bed"
-# filter_file_intersect_policy: "midpoint"
-# filter_file_workers: 1
-
-# Mappability parameters
-
+# --- Mappability (interval filtering) ---------------------------------------
 # mappability_file: "mappability.bw"
 # mappability_threshold: 0.00
 
-# Frag-length-bins parameters
+# --- filter-file ------------------------------------------------------------
+# filter_file: True
+# filter_file_whitelist: "whitelist.bed"   # -w/--whitelist
+# filter_file_blacklist: "blacklist.bed"   # -b/--blacklist
+# filter_file_mapq: 30                      # -q/--min-mapq
+# filter_file_min_length: 50                # --min-length
+# filter_file_max_length: 350               # --max-length
+# filter_file_intersect_policy: "midpoint"  # -p/--intersect-policy  (midpoint|any)
+
+# --- frag-length-bins -------------------------------------------------------
 # frag_length_bins: True
-# frag_length_bins_bin_size: 10
-# frag_length_bins_mapq: 30
-# frag_length_bins_policy: "midpoint"
-# frag_length_bins_min_len: 50
-# frag_length_bins_max_len: 350
-# frag_length_bins_chrom: "22"
-# frag_length_bins_start: 0
-# frag_length_bins_end: 41000000
+# frag_length_bins_reference: "ref.fa"      # -r/--reference  (CRAM only)
+# frag_length_bins_mapq: 30                 # -q/--min-mapq
+# frag_length_bins_bin_size: 10             # --bin-size
+# frag_length_bins_policy: "midpoint"       # -p/--intersect-policy
+# frag_length_bins_min_len: 50              # --min-length
+# frag_length_bins_max_len: 350             # --max-length
+# frag_length_bins_chrom: "22"              # -c/--contig
+# frag_length_bins_start: 0                 # -S/--start
+# frag_length_bins_end: 41000000            # -E/--stop
+# frag_length_bins_summary_stats: True      # --summary-stats
+# frag_length_bins_short_fraction: 150      # --short-threshold
 
-# Frag-length-intervals parameters
+# --- frag-length-intervals --------------------------------------------------
 # frag_length_intervals: True
-# frag_length_intervals_mapq: 30
-# frag_length_intervals_policy: "midpoint"
-# frag_length_intervals_min_len: 50
-# frag_length_intervals_max_len: 350
-# frag_length_intervals_workers: 1
+# frag_length_intervals_reference: "ref.fa" # -r/--reference  (CRAM only)
+# frag_length_intervals_mapq: 30            # -q/--min-mapq
+# frag_length_intervals_policy: "midpoint"  # -p/--intersect-policy
+# frag_length_intervals_min_len: 50         # --min-length
+# frag_length_intervals_max_len: 350        # --max-length
+# frag_length_intervals_short_reads: 150    # --short-threshold
+# frag_length_intervals_workers: 1          # -t/--threads
 
+# --- coverage ---------------------------------------------------------------
 # coverage: True
-# coverage_mapq: 30
-# coverage_intersect_policy: "any"
-# coverage_min_len: 50
-# coverage_max_len: 350
-# coverage_workers: 1
-# coverage_normalize: True
-# coverage_scale_factor: 1000000
+# coverage_reference: "ref.fa"              # -r/--reference  (CRAM only)
+# coverage_mapq: 30                         # -q/--min-mapq
+# coverage_intersect_policy: "any"          # -p/--intersect-policy
+# coverage_min_len: 50                      # --min-length
+# coverage_max_len: 350                     # --max-length
+# coverage_normalize: True                  # -n/--normalize
+# coverage_scale_factor: 1000000            # --scale-factor
+# coverage_workers: 1                       # -t/--threads
 
+# --- end-motifs -------------------------------------------------------------
 # end_motifs: True
-# end_motifs_kmer_length: 5
-# end_motifs_min_len: 50
-# end_motifs_max_len: 350
-# end_motifs_no_both_strands: True
-# end_motifs_negative_strand: False
-# end_motifs_mapq: 30
-# end_motifs_workers: 1
+# end_motifs_refseq_file: "ref.2bit"        # REFERENCE positional (.2bit or FASTA)
+# end_motifs_kmer_length: 4                 # -k/--kmer-length
+# end_motifs_min_len: 50                    # --min-length
+# end_motifs_max_len: 350                   # --max-length
+# end_motifs_strand: "both"                 # --strand  (both|forward|reverse)
+# end_motifs_mapq: 30                       # -q/--min-mapq
+# end_motifs_workers: 1                     # -t/--threads
 
+# --- interval-end-motifs ----------------------------------------------------
 # interval_end_motifs: True
 # interval_end_motifs_refseq_file: "ref.2bit"
-# interval_end_motifs_kmer_length: 4
-# interval_end_motifs_min_len: 50
-# interval_end_motifs_max_len: 350
-# interval_end_motifs_single_strand: False
-# interval_end_motifs_negative_strand: False
-# interval_end_motifs_mapq: 30
-# interval_end_motifs_workers: 1
+# interval_end_motifs_kmer_length: 4        # -k/--kmer-length
+# interval_end_motifs_min_len: 50           # --min-length
+# interval_end_motifs_max_len: 350          # --max-length
+# interval_end_motifs_strand: "both"        # --strand  (both|forward|reverse)
+# interval_end_motifs_mapq: 30              # -q/--min-mapq
+# interval_end_motifs_workers: 1            # -t/--threads
 
+# --- breakpoint-motifs ------------------------------------------------------
+# breakpoint_motifs: True
+# breakpoint_motifs_refseq_file: "ref.2bit"
+# breakpoint_motifs_kmer_length: 6          # -k/--kmer-length
+# breakpoint_motifs_min_len: 50             # --min-length
+# breakpoint_motifs_max_len: 350            # --max-length
+# breakpoint_motifs_strand: "both"          # --strand  (both|forward|reverse)
+# breakpoint_motifs_mapq: 30                # -q/--min-mapq
+# breakpoint_motifs_workers: 1              # -t/--threads
+
+# --- interval-breakpoint-motifs ---------------------------------------------
+# interval_breakpoint_motifs: True
+# interval_breakpoint_motifs_refseq_file: "ref.2bit"
+# interval_breakpoint_motifs_kmer_length: 6
+# interval_breakpoint_motifs_min_len: 50
+# interval_breakpoint_motifs_max_len: 350
+# interval_breakpoint_motifs_strand: "both" # --strand  (both|forward|reverse)
+# interval_breakpoint_motifs_mapq: 30
+# interval_breakpoint_motifs_workers: 1
+
+# --- mds (needs end_motifs) -------------------------------------------------
 # mds: True
-# mds_sep: " "
-# mds_header: 0
+# mds_sep: " "                              # -s/--sep
+# mds_header: 0                             # --header
 
-# interval_mds: True
-# interval_mds_sep: " "
-# interval_mds_header: 0
+# --- regional-mds (needs interval_end_motifs) -------------------------------
+# regional_mds: True
+# regional_mds_sep: " "                     # -s/--sep
+# regional_mds_header: 0                    # --header
 
+# --- wps --------------------------------------------------------------------
 # wps: True
-# wps_chrom_sizes: "ref.chrom.sizes"
-# wps_site_bed: "sites.bed"
-# wps_interval_size: 5000
-# wps_window_size: 120
-# wps_min_len: 120
-# wps_max_len: 180
-# wps_mapq: 30
-# wps_workers: 4
+# wps_site_bed: "sites.bed"                 # REGIONS positional
+# wps_reference: "ref.fa"                   # -r/--reference  (CRAM only)
+# wps_chrom_sizes: "ref.chrom.sizes"        # --chrom-sizes
+# wps_interval_size: 5000                   # -i/--interval-size
+# wps_window_size: 120                      # -W/--window-size
+# wps_min_len: 120                          # --min-length
+# wps_max_len: 180                          # --max-length
+# wps_mapq: 30                              # -q/--min-mapq
+# wps_workers: 4                            # -t/--threads
 
+# --- adjust-wps (needs wps) -------------------------------------------------
 # adjust_wps: True
-# adjust_wps_interval_file: "sites.bed"
-# adjust_wps_chrom_sizes: "ref.chrom.sizes"
-# adjust_wps_interval_size: 5000
-# adjust_wps_median_window_size: 200
-# adjust_wps_savgol_window_size: 21
-# adjust_wps_savgol_poly_deg: 2
-# adjust_wps_exclude_savgol: True
-# adjust_wps_workers: 4
-# adjust_wps_mean: False
-# adjust_wps_subtract_edges: True
-# adjust_wps_edge_size: 500 # Breaks functionality for some reason
+# adjust_wps_chrom_sizes: "ref.chrom.sizes" # CHROM_SIZES positional
+# adjust_wps_interval_size: 5000            # -i/--interval-size
+# adjust_wps_median_window_size: 200        # -m/--median-window-size
+# adjust_wps_savgol_window_size: 21         # --savgol-window-size
+# adjust_wps_savgol_poly_deg: 2             # --savgol-poly-deg
+# adjust_wps_savgol: True                   # --savgol/--no-savgol  (set False to disable)
+# adjust_wps_mean: False                    # --mean
+# adjust_wps_subtract_edges: True           # --subtract-edges
+# adjust_wps_edge_size: 500                 # --edge-size
+# adjust_wps_workers: 4                     # -t/--threads
 
+# --- delfi ------------------------------------------------------------------
 # delfi: True
-# Only one of the two parameters below need to be given
-# delfi_gap_file: "ref.gap.bed"
-# delfi_gap_reference_genome: "ref"
-# delfi_chrom_sizes: "ref.chrom.sizes"
-# delfi_reference_file: "ref.2bit"
-# delfi_bins_file: "interval.bins"
-# delfi_no_gc_correct: False
-# delfi_keep_nocov: False
-# delfi_no_merge_bins: True
-# delfi_window_size: 5000000
-# delfi_mapq: 30
-# delfi_workers: 4
+# delfi_chrom_sizes: "ref.chrom.sizes"      # CHROM_SIZES positional
+# delfi_reference_file: "ref.2bit"          # REFERENCE positional (.2bit or FASTA)
+# delfi_bins_file: "interval.bins"          # BINS positional
+# delfi_blacklist_file: "blacklist.bed"     # -b/--blacklist
+# Give at most one of the two gap options:
+# delfi_gap_file: "ref.gap.bed"             # -g/--gap-file (a BED4 file)
+# delfi_gap_reference_genome: "hg38"        # -g/--gap-file (a genome name; gap-bed is generated)
+# delfi_no_gc_correct: False                # --no-gc-correct
+# delfi_remove_nocov: True                  # --remove-nocov/--no-remove-nocov (set False to keep them)
+# delfi_merge_bins: True                    # --merge-bins/--no-merge-bins (set False to keep input bins)
+# delfi_merge_size: 5000000                 # --merge-size
+# delfi_mapq: 30                            # -q/--min-mapq
+# delfi_workers: 4                          # -t/--threads
 
+# --- cleavage-profile -------------------------------------------------------
 # cleavage_profile: True
-# cleavage_profile_chrom_sizes: "ref.chrom.sizes"
-# cleavage_profile_min_len: 50
-# cleavage_profile_max_len: 350
-# cleavage_profile_mapq: 30
-# cleavage_profile_left: 2000
-# cleavage_profile_right: 2000
-# cleavage_profile_workers: 8
+# cleavage_profile_chrom_sizes: "ref.chrom.sizes"  # CHROM_SIZES positional
+# cleavage_profile_reference: "ref.fa"      # -r/--reference  (CRAM only)
+# cleavage_profile_min_len: 50              # --min-length
+# cleavage_profile_max_len: 350             # --max-length
+# cleavage_profile_mapq: 30                 # -q/--min-mapq
+# cleavage_profile_left: 2000               # --pad-left
+# cleavage_profile_right: 2000              # --pad-right
+# cleavage_profile_workers: 8               # -t/--threads
 
+# --- agg-bw (needs cleavage_profile) ----------------------------------------
 # agg_bw: True
-# agg_bw_median_window_size: 1
-# agg_bw_mean: True
+# agg_bw_median_window_size: 1              # -m/--median-window-size
+# agg_bw_mean: True                         # --mean


### PR DESCRIPTION
## Summary

Updates the Snakemake workflow for the **FinaleToolkit 1.0.0** command-line interface.

- Re-port the `Snakefile` and example configs to the current CLI flags (`--min-length`/`--max-length`, `-t` threads, `--chrom-sizes`, `-r` reference), `regional_mds`, and the DELFI `remove_nocov`/`merge_bins` options.
- Every CLI option is represented in `params.yaml` (the rewrite CLI is the source of truth).
- Drop obsolete dependency pins from `environment.yml`; ignore `.DS_Store`.
- README points to the published FinaleToolkit workflow guide and aligns badges with the main project.

Companion to epifluidlab/FinaleToolkit#180 (FinaleToolkit v1.0.0).
