### PR TITLE
Update workflow for FinaleToolkit 1.0.0 CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 input/
 output/
 supplement/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
 # FinaleToolkit Workflow
 
-This Snakemake workflow automates the extraction of epigenomic features using Finaletoolkit, supporting parallel processing, SLURM, and common genomic file formats.
+This Snakemake workflow automates the extraction of epigenomic features using Finaletoolkit, supporting parallel processing, SLURM, and common genomic file formats. It targets **FinaleToolkit 1.0.0**, which introduced a redesigned CLI (see the [Migration to FinaleToolkit 1.0.0](#migration-to-finaletoolkit-100) section).
 
 ## Key Features
 
-*   **Finaletoolkit Support:** Implements most Finaletoolkit CLI commands (excluding `gap-bed` and `delfi-gc-correct`).
+*   **Finaletoolkit Support:** Implements most Finaletoolkit 1.0.0 CLI commands. (`delfi-gc-correct` was removed in 1.0.0 — GC correction now runs automatically inside `delfi`; `gap-bed` is not exposed directly but is used internally by the `delfi` step.)
 *   **File Compatibility:** Works with BED, BAM, and CRAM files.
 *   **Mappability Filtering:** Filters interval files based on mappability scores.
 *   **Parallelization:** Supports multi-core processing.
@@ -90,7 +90,7 @@ snakemake  --profile slurm_profile > snakemake.log 2>&1 &
     *   `finaletoolkit_command: True/False`: Enables a specific Finaletoolkit command, using hyphens replaced by
     underscores (e.g., `adjust-wps` becomes `adjust_wps: True`).
     *   `finaletoolkit_command_flag: value`: Sets flags for a Finaletoolkit command (e.g.,
-    `adjust_wps_max_length: 250`). Flags that take input files, output files, or `verbose` flags do not exist here.  `mapping_quality` is shortened to `mapq` for flags (e.g., `coverage_mapping_quality` becomes `coverage_mapq`).
+    `adjust_wps_max_length: 250`). Flags that take input files, output files, or `verbose` flags do not exist here.  `mapping_quality` is shortened to `mapq` for flags (e.g., `coverage_mapping_quality` becomes `coverage_mapq`). Config keys follow FinaleToolkit 1.0.0 terminology — worker counts use `_threads`, fragment bounds use `_min_length`/`_max_length`, motif strand selection uses a single `_strand` key (`both`/`forward`/`reverse`), and cleavage padding uses `_pad_left`/`_pad_right`.
 
 ## Output File Naming
 
@@ -107,12 +107,34 @@ snakemake  --profile slurm_profile > snakemake.log 2>&1 &
 
 *   Finaletoolkit commands are specified in `params.yaml` with underscores instead of hyphens.
 *   Set command flags by appending `_<flag_name>` to the converted command name.
-*   This workflow respects command dependencies.  For example, `adjust-wps` requires `wps` output, and `mds` needs `end-motifs`.
+*   This workflow respects command dependencies.  For example, `adjust-wps` requires `wps` output, `mds` needs `end-motifs`, and `regional_mds` (renamed from `interval-mds` in 1.0.0) needs `interval-end-motifs`.
 
 ## `filter-file` Command
 
 *   If only `filter-file` is set to `True`, the output of the workflow will be only the filtered files.
 *   If any other Finaletoolkit commands are set, they will use the output of `filter-file` as their input.
+
+## Migration to FinaleToolkit 1.0.0
+
+FinaleToolkit 1.0.0 redesigned its CLI, so several `params.yaml` config keys were renamed to match. If you are upgrading an existing `params.yaml`, update the following keys:
+
+| Old key | New key |
+| --- | --- |
+| `<command>_workers`, `workers` | `<command>_threads`, `threads` |
+| `<command>_min_len` / `<command>_max_len` | `<command>_min_length` / `<command>_max_length` |
+| `<motif>_single_strand` + `<motif>_negative_strand` | `<motif>_strand` (`both` / `forward` / `reverse`) |
+| `cleavage_profile_left` / `cleavage_profile_right` | `cleavage_profile_pad_left` / `cleavage_profile_pad_right` |
+| `frag_length_bins_short_fraction` | `frag_length_bins_short_threshold` |
+| `frag_length_intervals_short_reads` | `frag_length_intervals_short_threshold` |
+| `adjust_wps_exclude_savgol: True` | `adjust_wps_savgol: False` (meaning inverted; savgol is on by default) |
+| `delfi_window_size` | `delfi_merge_size` |
+| `delfi_keep_nocov: True` | `delfi_remove_nocov: False` (meaning inverted; removal is on by default) |
+| `delfi_no_merge_bins: True` | `delfi_merge_bins: False` (meaning inverted; merging is on by default) |
+| `interval_mds` (and `interval_mds_sep` / `interval_mds_header`) | `regional_mds` (and `regional_mds_sep` / `regional_mds_header`) |
+
+Motif strand selection: use `_strand: "forward"` for the old `single_strand: True` (positive strand only) and `_strand: "reverse"` for `single_strand: True` + `negative_strand: True`. The default `both` matches the old default.
+
+Output note: the `regional_mds` outputs land in `output/regional_mds/*.regional_mds.tsv` (previously `interval_mds`).
 
 ## Notes
 

--- a/Snakefile
+++ b/Snakefile
@@ -41,7 +41,7 @@ coverage_dir                   = os.path.join(out_dir, "coverage")
 end_motifs_dir                 = os.path.join(out_dir, "end_motifs")
 interval_end_motifs_dir        = os.path.join(out_dir, "interval_end_motifs")
 mds_dir                        = os.path.join(out_dir, "mds")
-interval_mds_dir               = os.path.join(out_dir, "interval_mds")
+regional_mds_dir               = os.path.join(out_dir, "regional_mds")
 wps_dir                        = os.path.join(out_dir, "wps")
 adjust_wps_dir                 = os.path.join(out_dir, "adjust_wps")
 delfi_dir                      = os.path.join(out_dir, "delfi")
@@ -57,7 +57,7 @@ coverage = config.get("coverage", False)
 end_motifs = config.get("end_motifs", False)
 interval_end_motifs = config.get("interval_end_motifs", False)
 mds = config.get("mds", False)
-interval_mds = config.get("interval_mds", False)
+regional_mds = config.get("regional_mds", False)
 wps = config.get("wps", False)
 adjust_wps = config.get("adjust_wps", False)
 delfi = config.get("delfi", False)
@@ -72,8 +72,8 @@ if (adjust_wps and not wps):
 if (mds and not end_motifs):
     raise SystemExit("end-motifs is required to run mds.")
 
-if (interval_mds and not interval_end_motifs):
-    raise SystemExit("interval-end-motifs is required to run interval-mds.")
+if (regional_mds and not interval_end_motifs):
+    raise SystemExit("interval-end-motifs is required to run regional-mds.")
 
 if (file_format != "bam" and file_format != "cram" and file_format != "bed.gz" and file_format != "frag.gz"):
     raise SystemExit('File format must be of type "bed.gz," "bam," or "cram."')
@@ -85,7 +85,7 @@ elif file_format == "cram":
 elif file_format == "bed.gz" or file_format == "frag.gz":
     index = "tbi"
 
-using_finaletoolkit = frag_length_bins or frag_length_intervals or coverage or end_motifs or interval_end_motifs or mds or interval_mds or wps or adjust_wps or delfi or cleavage_profile or agg_bw or breakpoint_motifs or interval_breakpoint_motifs
+using_finaletoolkit = frag_length_bins or frag_length_intervals or coverage or end_motifs or interval_end_motifs or mds or regional_mds or wps or adjust_wps or delfi or cleavage_profile or agg_bw or breakpoint_motifs or interval_breakpoint_motifs
 
 # Set the expand function for the files.
 def io(endings, samples, condition, dir=out_dir):
@@ -119,7 +119,7 @@ rule all:
             io(["end_motifs.tsv"], value, end_motifs, end_motifs_dir) +
             io(["interval_end_motifs.tsv"], value, interval_end_motifs, interval_end_motifs_dir) +
             io(["mds.txt"], value, mds, mds_dir) +
-            io(["interval_mds.tsv"], value, interval_mds, interval_mds_dir) +
+            io(["regional_mds.tsv"], value, regional_mds, regional_mds_dir) +
             io(["wps.bw"], value, wps, wps_dir) +
             io(["adjust_wps.bw"], value, adjust_wps, adjust_wps_dir) +
             io(["delfi.bed"], value, delfi, delfi_dir) +
@@ -143,17 +143,17 @@ rule filter_file:
         filter_file_mapq = config.get("filter_file_mapq", 0),
         filter_file_min_length = config.get("filter_file_min_length", 0),
         filter_file_max_length = config.get("filter_file_max_length", sys.maxsize),
-        filter_file_blacklist = os.path.join(sup_dir, config['filter_file_blacklist']) if 'filter_file_blacklist' in config else None,
-        filter_file_whitelist = os.path.join(sup_dir, config['filter_file_whitelist']) if 'filter_file_whitelist' in config else None,
+        filter_file_blacklist = os.path.join(sup_dir, config['filter_file_blacklist_file']) if 'filter_file_blacklist_file' in config else None,
+        filter_file_whitelist = os.path.join(sup_dir, config['filter_file_whitelist_file']) if 'filter_file_whitelist_file' in config else None,
         filter_file_intersect_policy = config.get("filter_file_intersect_policy", "midpoint"),
-        filter_file_workers = config.get("workers", 1)
+        filter_file_threads = config.get("threads", 1)
     run:
         if filter_file:
             command = f"""finaletoolkit filter-file \
-                {f" -W {params.filter_file_whitelist}" if params.filter_file_whitelist else ""} \
-                {f" -B {params.filter_file_blacklist}" if params.filter_file_blacklist else ""} \
-                -o {output.main} -q {params.filter_file_mapq} -min {params.filter_file_min_length} -max {params.filter_file_max_length} \
-                -p {params.filter_file_intersect_policy} -w {params.filter_file_workers} {input.main}"""
+                {f" -w {params.filter_file_whitelist}" if params.filter_file_whitelist else ""} \
+                {f" -b {params.filter_file_blacklist}" if params.filter_file_blacklist else ""} \
+                -o {output.main} -q {params.filter_file_mapq} --min-length {params.filter_file_min_length} --max-length {params.filter_file_max_length} \
+                -p {params.filter_file_intersect_policy} -t {params.filter_file_threads} {input.main}"""
             shell(command)
         else:
             shell(f"cp {input.main} {output.main}")
@@ -183,13 +183,13 @@ rule frag_length_bins:
         mapq = config.get("frag_length_bins_mapq"),
         bin_size = config.get("frag_length_bins_bin_size"),
         policy = config.get("frag_length_bins_policy"),
-        min_len = config.get("frag_length_bins_min_len"),
-        max_len = config.get("frag_length_bins_max_len"),
+        min_len = config.get("frag_length_bins_min_length"),
+        max_len = config.get("frag_length_bins_max_length"),
         chrom = config.get("frag_length_bins_chrom"),
         start = config.get("frag_length_bins_start"),
         end = config.get("frag_length_bins_end"),
         summary_stats = config.get("frag_length_bins_summary_stats", False),
-        short_fraction = config.get("frag_length_bins_short_fraction"),
+        short_threshold = config.get("frag_length_bins_short_threshold"),
         reference_file = config.get("frag_length_bins_reference_file")
     run:
         command_parts = [f"finaletoolkit frag-length-bins {input}"]
@@ -202,9 +202,9 @@ rule frag_length_bins:
         if params.policy is not None:
             command_parts.append(f"-p {params.policy}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.chrom is not None and params.chrom != "":
             command_parts.append(f"-c {params.chrom}")
         if params.start is not None:
@@ -212,11 +212,11 @@ rule frag_length_bins:
         if params.end is not None:
             command_parts.append(f"-E {params.end}")
         if params.summary_stats:
-            command_parts.append("-stats")
-            if params.short_fraction is not None:
-                command_parts.append(f"-sf {params.short_fraction}")
+            command_parts.append("--summary-stats")
+            if params.short_threshold is not None:
+                command_parts.append(f"--short-threshold {params.short_threshold}")
         command_parts.append(f"-o {output.tsv}")
-        command_parts.append(f"--histogram-path {output.png} -v")
+        command_parts.append(f"--histogram {output.png} -v")
         command = " ".join(command_parts)
         print("Running: ", command)
         shell(f"{command}")
@@ -227,14 +227,14 @@ rule frag_length_intervals:
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}" + ".filtered")
     output:
         os.path.join(frag_length_intervals_dir, "{sample}.frag_length_intervals.bed")
-    threads: config.get("frag_length_intervals_workers")
+    threads: config.get("frag_length_intervals_threads")
     params:
-        min_len = config.get("frag_length_intervals_min_len"),
-        max_len = config.get("frag_length_intervals_max_len"),
+        min_len = config.get("frag_length_intervals_min_length"),
+        max_len = config.get("frag_length_intervals_max_length"),
         policy = config.get("frag_length_intervals_policy"),
         mapq = config.get("frag_length_intervals_mapq"),
-        workers = config.get("frag_length_intervals_workers"),
-        short_reads = config.get("frag_length_intervals_short_reads"),
+        threads = config.get("frag_length_intervals_threads"),
+        short_threshold = config.get("frag_length_intervals_short_threshold"),
         reference_file = config.get("frag_length_intervals_reference_file")
     run:
         command_parts = [
@@ -247,17 +247,17 @@ rule frag_length_intervals:
         if params.reference_file is not None:
             command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.policy is not None:
             command_parts.append(f"-p {params.policy}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
-        if params.short_reads is not None:
-            command_parts.append(f"-s {params.short_reads}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
+        if params.short_threshold is not None:
+            command_parts.append(f"--short-threshold {params.short_threshold}")
 
         command_parts.append(f"-o {output[0]} -v")  # Ensure output indexing
 
@@ -272,15 +272,15 @@ rule coverage:
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}" + ".filtered")
     output:
         os.path.join(coverage_dir, "{sample}.coverage.bed")
-    threads: config.get("coverage_workers")
+    threads: config.get("coverage_threads")
     params:
-        min_len = config.get("coverage_min_len"),
-        max_len = config.get("coverage_max_len"),
+        min_len = config.get("coverage_min_length"),
+        max_len = config.get("coverage_max_length"),
         normalize = config.get("coverage_normalize", False),
         scale_factor = config.get("coverage_scale_factor"),
         intersect_policy = config.get("coverage_intersect_policy"),
         mapq = config.get("coverage_mapq"),
-        workers = config.get("coverage_workers"),
+        threads = config.get("coverage_threads"),
         reference_file = config.get("coverage_reference_file")
     run:
         command_parts = [
@@ -293,14 +293,14 @@ rule coverage:
         if params.reference_file is not None:
             command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
         if params.normalize:
             command_parts.append("-n")
             if params.scale_factor is not None:
-                command_parts.append(f"-s {params.scale_factor}")
+                command_parts.append(f"--scale-factor {params.scale_factor}")
 
         if params.intersect_policy is not None:
             command_parts.append(f"-p {params.intersect_policy}")
@@ -308,8 +308,8 @@ rule coverage:
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
 
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
 
         command_parts.append(f"-o {output} -v")
 
@@ -323,15 +323,14 @@ rule end_motifs:
         refseq = os.path.join(sup_dir, f"{config.get('end_motifs_refseq_file')}")
     output:
         os.path.join(end_motifs_dir, "{sample}.end_motifs.tsv")
-    threads: config.get("end_motifs_workers")
+    threads: config.get("end_motifs_threads")
     params:
         kmer_length = config.get("end_motifs_kmer_length"),
-        min_len = config.get("end_motifs_min_len"),
-        max_len = config.get("end_motifs_max_len"),
-        single_strand = config.get("end_motifs_single_strand", False),
-        negative_strand = config.get("end_motifs_negative_strand", False),
+        min_len = config.get("end_motifs_min_length"),
+        max_len = config.get("end_motifs_max_length"),
+        strand = config.get("end_motifs_strand"),
         mapq = config.get("end_motifs_mapq"),
-        workers = config.get("end_motifs_workers")
+        threads = config.get("end_motifs_threads")
     run:
         command_parts = [
             "finaletoolkit",
@@ -343,19 +342,17 @@ rule end_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None and params.strand != "both":
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
         command_parts.append(f"-o {output} -v")
 
         command = " ".join(command_parts)
@@ -369,15 +366,14 @@ rule interval_end_motifs:
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}.filtered")
     output:
         os.path.join(interval_end_motifs_dir, "{sample}.interval_end_motifs.tsv")
-    threads: config.get("interval_end_motifs_workers")
+    threads: config.get("interval_end_motifs_threads")
     params:
         kmer_length = config.get("interval_end_motifs_kmer_length"),
-        min_len = config.get("interval_end_motifs_min_len"),
-        max_len = config.get("interval_end_motifs_max_len"),
-        single_strand = config.get("interval_end_motifs_single_strand", False),
-        negative_strand = config.get("interval_end_motifs_negative_strand", False),
+        min_len = config.get("interval_end_motifs_min_length"),
+        max_len = config.get("interval_end_motifs_max_length"),
+        strand = config.get("interval_end_motifs_strand"),
         mapq = config.get("interval_end_motifs_mapq"),
-        workers = config.get("interval_end_motifs_workers")
+        threads = config.get("interval_end_motifs_threads")
     run:
         command_parts = [
             "finaletoolkit",
@@ -390,19 +386,17 @@ rule interval_end_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None and params.strand != "both":
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
         command_parts.append(f"-o {output[0]} -v")
 
         command = " ".join(command_parts)
@@ -428,23 +422,23 @@ rule mds:
         if params.header is not None:
             command_parts.append(f"--header {params.header}")
 
-        # Redirect output to the file
-        command = " ".join(command_parts) + f" {output[0]}"
+        # mds writes to stdout in FinaleToolkit 1.0.0; redirect it to the output file
+        command = " ".join(command_parts) + f" > {output[0]}"
         print("Running: ", command)
         shell(f"{command}")
 
-rule interval_mds:
+rule regional_mds:
     input:
         os.path.join(interval_end_motifs_dir, "{sample}.interval_end_motifs.tsv")
     output:
-        os.path.join(interval_mds_dir, "{sample}.interval_mds.tsv")
+        os.path.join(regional_mds_dir, "{sample}.regional_mds.tsv")
     params:
-        sep = config.get("interval_mds_sep", " "),
-        header = config.get("interval_mds_header")
+        sep = config.get("regional_mds_sep", " "),
+        header = config.get("regional_mds_header")
     run:
         command_parts = [
             "finaletoolkit",
-            "interval-mds",
+            "regional-mds",
             input[0],  # Accessing the input file properly
         ]
         if params.sep is not None and params.sep != " ":
@@ -463,34 +457,34 @@ rule wps:
         site_bed = os.path.join(sup_dir, f"{config.get('wps_site_bed')}")
     output:
         os.path.join(wps_dir, "{sample}.wps.bw")
-    threads: config.get("wps_workers")
+    threads: config.get("wps_threads")
     params:
         chrom_sizes = config.get("wps_chrom_sizes"),
         interval_size = config.get("wps_interval_size"),
         window_size = config.get("wps_window_size"),
-        min_len = config.get("wps_min_len"),
-        max_len = config.get("wps_max_len"),
+        min_len = config.get("wps_min_length"),
+        max_len = config.get("wps_max_length"),
         mapq = config.get("wps_mapq"),
-        workers = config.get("wps_workers"),
+        threads = config.get("wps_threads"),
         reference_file = config.get("wps_reference_file")
     run:
         command_parts = ["finaletoolkit", "wps", input.data, input.site_bed]
         if params.reference_file is not None:
             command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.chrom_sizes is not None:
-            command_parts.append(f"-c {os.path.join(sup_dir, params.chrom_sizes)}")
+            command_parts.append(f"--chrom-sizes {os.path.join(sup_dir, params.chrom_sizes)}")
         if params.interval_size is not None:
             command_parts.append(f"-i {params.interval_size}")
         if params.window_size is not None:
             command_parts.append(f"-W {params.window_size}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
         command_parts.append(f"-o {output[0]} -v")
         command = " ".join(command_parts)
         print("Running: ", command)
@@ -503,14 +497,14 @@ rule adjust_wps:
         chrom_sizes = os.path.join(sup_dir, f"{config.get('adjust_wps_chrom_sizes')}")
     output:
         os.path.join(adjust_wps_dir, "{sample}.adjust_wps.bw")
-    threads: config.get("adjust_wps_workers")
+    threads: config.get("adjust_wps_threads")
     params:
         interval_size = config.get("adjust_wps_interval_size"),
         median_window_size = config.get("adjust_wps_median_window_size"),
         savgol_window_size = config.get("adjust_wps_savgol_window_size"),
         savgol_poly_deg = config.get("adjust_wps_savgol_poly_deg"),
-        exclude_savgol = config.get("adjust_wps_exclude_savgol", False),
-        workers = config.get("adjust_wps_workers"),
+        savgol = config.get("adjust_wps_savgol", True),
+        threads = config.get("adjust_wps_threads"),
         mean = config.get("adjust_wps_mean", False),
         subtract_edges = config.get("adjust_wps_subtract_edges", False),
         edge_size = config.get("adjust_wps_edge_size")
@@ -528,13 +522,13 @@ rule adjust_wps:
         if params.median_window_size is not None:
             command_parts.append(f"-m {params.median_window_size}")
         if params.savgol_window_size is not None:
-            command_parts.append(f"-s {params.savgol_window_size}")
+            command_parts.append(f"--savgol-window-size {params.savgol_window_size}")
         if params.savgol_poly_deg is not None:
-            command_parts.append(f"-p {params.savgol_poly_deg}")
-        if params.exclude_savgol:
-            command_parts.append("-S")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+            command_parts.append(f"--savgol-poly-deg {params.savgol_poly_deg}")
+        if not params.savgol:
+            command_parts.append("--no-savgol")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
         if params.mean:
             command_parts.append("--mean")
         if params.subtract_edges:
@@ -554,17 +548,17 @@ rule delfi:
         bins_file = os.path.join(sup_dir, f"{config.get('delfi_bins_file')}")
     output:
         os.path.join(delfi_dir, "{sample}.delfi.bed")
-    threads: config.get("delfi_workers")
+    threads: config.get("delfi_threads")
     params:
         blacklist_file = config.get("delfi_blacklist_file"),
         gap_file = config.get("delfi_gap_file"),
         gap_reference_genome = config.get("delfi_gap_reference_genome"),
         no_gc_correct = config.get("delfi_no_gc_correct", False),
-        keep_nocov = config.get("delfi_keep_nocov", False),
-        no_merge_bins = config.get("delfi_no_merge_bins", False),
-        window_size = config.get("delfi_window_size"),
+        remove_nocov = config.get("delfi_remove_nocov", True),
+        merge_bins = config.get("delfi_merge_bins", True),
+        merge_size = config.get("delfi_merge_size"),
         mapq = config.get("delfi_mapq"),
-        workers = config.get("delfi_workers")
+        threads = config.get("delfi_threads")
     run:
 
         command_parts = [
@@ -587,17 +581,17 @@ rule delfi:
             command_parts.append(f"-g {os.path.join(sup_dir, params.gap_file)}")
 
         if params.no_gc_correct:
-            command_parts.append("-G")
-        if params.keep_nocov:
-            command_parts.append("-R")
-        if params.no_merge_bins:
-            command_parts.append("-M")
-        if params.window_size is not None:
-            command_parts.append(f"-s {params.window_size}")
+            command_parts.append("--no-gc-correct")
+        if not params.remove_nocov:
+            command_parts.append("--no-remove-nocov")
+        if not params.merge_bins:
+            command_parts.append("--no-merge-bins")
+        if params.merge_size is not None:
+            command_parts.append(f"--merge-size {params.merge_size}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
 
         command_parts.append(f"-o {output[0]} -v")
 
@@ -612,14 +606,14 @@ rule cleavage_profile:
         chrom_sizes = os.path.join(sup_dir, f"{config.get('cleavage_profile_chrom_sizes')}")
     output:
         os.path.join(cleavage_profile_dir, "{sample}.cleavage_profile.bw")
-    threads: config.get("cleavage_profile_workers")
+    threads: config.get("cleavage_profile_threads")
     params:
-        min_len = config.get("cleavage_profile_min_len"),
-        max_len = config.get("cleavage_profile_max_len"),
+        min_len = config.get("cleavage_profile_min_length"),
+        max_len = config.get("cleavage_profile_max_length"),
         mapq = config.get("cleavage_profile_mapq"),
-        left = config.get("cleavage_profile_left"),
-        right = config.get("cleavage_profile_right"),
-        workers = config.get("cleavage_profile_workers"),
+        pad_left = config.get("cleavage_profile_pad_left"),
+        pad_right = config.get("cleavage_profile_pad_right"),
+        threads = config.get("cleavage_profile_threads"),
         reference_file = config.get("cleavage_profile_reference_file")
     run:
         command_parts = [
@@ -631,19 +625,19 @@ rule cleavage_profile:
         ]
 
         if params.reference_file is not None:
-            command_parts.append(f"--reference-file {os.path.join(sup_dir, params.reference_file)}")
+            command_parts.append(f"--reference {os.path.join(sup_dir, params.reference_file)}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.left is not None:
-            command_parts.append(f"-l {params.left}")
-        if params.right is not None:
-            command_parts.append(f"-r {params.right}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.pad_left is not None:
+            command_parts.append(f"--pad-left {params.pad_left}")
+        if params.pad_right is not None:
+            command_parts.append(f"--pad-right {params.pad_right}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
 
         command_parts.append(f"-o {output[0]} -v")
         command = " ".join(command_parts)
@@ -671,7 +665,7 @@ rule agg_bw:
         if params.median_window_size is not None:
             command_parts.append(f"-m {params.median_window_size}")
         if params.mean:
-            command_parts.append("-a")
+            command_parts.append("--mean")
 
         command_parts.append(f"-o {output[0]}")
         command_parts.append("-v")
@@ -686,15 +680,14 @@ rule breakpoint_motifs:
         refseq = os.path.join(sup_dir, f"{config.get('breakpoint_motifs_refseq_file')}")
     output:
         os.path.join(breakpoint_motifs_dir, "{sample}.breakpoint_motifs.tsv")
-    threads: config.get("breakpoint_motifs_workers")
+    threads: config.get("breakpoint_motifs_threads")
     params:
         kmer_length = config.get("breakpoint_motifs_kmer_length"),
-        min_len = config.get("breakpoint_motifs_min_len"),
-        max_len = config.get("breakpoint_motifs_max_len"),
-        single_strand = config.get("breakpoint_motifs_single_strand", False),
-        negative_strand = config.get("breakpoint_motifs_negative_strand", False),
+        min_len = config.get("breakpoint_motifs_min_length"),
+        max_len = config.get("breakpoint_motifs_max_length"),
+        strand = config.get("breakpoint_motifs_strand"),
         mapq = config.get("breakpoint_motifs_mapq"),
-        workers = config.get("breakpoint_motifs_workers")
+        threads = config.get("breakpoint_motifs_threads")
     run:
         command_parts = [
             "finaletoolkit",
@@ -706,19 +699,17 @@ rule breakpoint_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None and params.strand != "both":
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
         command_parts.append(f"-o {output} -v")
 
         command = " ".join(command_parts)
@@ -732,15 +723,14 @@ rule interval_breakpoint_motifs:
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}.filtered")
     output:
         os.path.join(interval_breakpoint_motifs_dir, "{sample}.interval_breakpoint_motifs.tsv")
-    threads: config.get("interval_breakpoint_motifs_workers")
+    threads: config.get("interval_breakpoint_motifs_threads")
     params:
         kmer_length = config.get("interval_breakpoint_motifs_kmer_length"),
-        min_len = config.get("interval_breakpoint_motifs_min_len"),
-        max_len = config.get("interval_breakpoint_motifs_max_len"),
-        single_strand = config.get("interval_breakpoint_motifs_single_strand", False),
-        negative_strand = config.get("interval_breakpoint_motifs_negative_strand", False),
+        min_len = config.get("interval_breakpoint_motifs_min_length"),
+        max_len = config.get("interval_breakpoint_motifs_max_length"),
+        strand = config.get("interval_breakpoint_motifs_strand"),
         mapq = config.get("interval_breakpoint_motifs_mapq"),
-        workers = config.get("interval_breakpoint_motifs_workers")
+        threads = config.get("interval_breakpoint_motifs_threads")
     run:
         command_parts = [
             "finaletoolkit",
@@ -753,19 +743,17 @@ rule interval_breakpoint_motifs:
         if params.kmer_length is not None:
             command_parts.append(f"-k {params.kmer_length}")
         if params.min_len is not None:
-            command_parts.append(f"-min {params.min_len}")
+            command_parts.append(f"--min-length {params.min_len}")
         if params.max_len is not None:
-            command_parts.append(f"-max {params.max_len}")
+            command_parts.append(f"--max-length {params.max_len}")
 
-        if params.single_strand:
-            command_parts.append("-B")
-            if params.negative_strand:
-                command_parts.append("-n")
+        if params.strand is not None and params.strand != "both":
+            command_parts.append(f"--strand {params.strand}")
 
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
-        if params.workers is not None:
-            command_parts.append(f"-w {params.workers}")
+        if params.threads is not None:
+            command_parts.append(f"-t {params.threads}")
         command_parts.append(f"-o {output[0]} -v")
 
         command = " ".join(command_parts)

--- a/Snakefile
+++ b/Snakefile
@@ -189,9 +189,12 @@ rule frag_length_bins:
         start = config.get("frag_length_bins_start"),
         end = config.get("frag_length_bins_end"),
         summary_stats = config.get("frag_length_bins_summary_stats", False),
-        short_fraction = config.get("frag_length_bins_short_fraction")
+        short_fraction = config.get("frag_length_bins_short_fraction"),
+        reference_file = config.get("frag_length_bins_reference_file")
     run:
         command_parts = [f"finaletoolkit frag-length-bins {input}"]
+        if params.reference_file is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.mapq is not None:
             command_parts.append(f"-q {params.mapq}")
         if params.bin_size is not None:
@@ -231,7 +234,8 @@ rule frag_length_intervals:
         policy = config.get("frag_length_intervals_policy"),
         mapq = config.get("frag_length_intervals_mapq"),
         workers = config.get("frag_length_intervals_workers"),
-        short_reads = config.get("frag_length_intervals_short_reads")
+        short_reads = config.get("frag_length_intervals_short_reads"),
+        reference_file = config.get("frag_length_intervals_reference_file")
     run:
         command_parts = [
             "finaletoolkit",
@@ -240,6 +244,8 @@ rule frag_length_intervals:
             input.intervals,
         ]
 
+        if params.reference_file is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.min_len is not None:
             command_parts.append(f"-min {params.min_len}")
         if params.max_len is not None:
@@ -274,7 +280,8 @@ rule coverage:
         scale_factor = config.get("coverage_scale_factor"),
         intersect_policy = config.get("coverage_intersect_policy"),
         mapq = config.get("coverage_mapq"),
-        workers = config.get("coverage_workers")
+        workers = config.get("coverage_workers"),
+        reference_file = config.get("coverage_reference_file")
     run:
         command_parts = [
             "finaletoolkit",
@@ -283,6 +290,8 @@ rule coverage:
             input.intervals,
         ]
 
+        if params.reference_file is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.min_len is not None:
             command_parts.append(f"-min {params.min_len}")
         if params.max_len is not None:
@@ -462,9 +471,12 @@ rule wps:
         min_len = config.get("wps_min_len"),
         max_len = config.get("wps_max_len"),
         mapq = config.get("wps_mapq"),
-        workers = config.get("wps_workers")
+        workers = config.get("wps_workers"),
+        reference_file = config.get("wps_reference_file")
     run:
         command_parts = ["finaletoolkit", "wps", input.data, input.site_bed]
+        if params.reference_file is not None:
+            command_parts.append(f"-r {os.path.join(sup_dir, params.reference_file)}")
         if params.chrom_sizes is not None:
             command_parts.append(f"-c {os.path.join(sup_dir, params.chrom_sizes)}")
         if params.interval_size is not None:
@@ -607,7 +619,8 @@ rule cleavage_profile:
         mapq = config.get("cleavage_profile_mapq"),
         left = config.get("cleavage_profile_left"),
         right = config.get("cleavage_profile_right"),
-        workers = config.get("cleavage_profile_workers")
+        workers = config.get("cleavage_profile_workers"),
+        reference_file = config.get("cleavage_profile_reference_file")
     run:
         command_parts = [
             "finaletoolkit",
@@ -617,6 +630,8 @@ rule cleavage_profile:
             input.chrom_sizes,
         ]
 
+        if params.reference_file is not None:
+            command_parts.append(f"--reference-file {os.path.join(sup_dir, params.reference_file)}")
         if params.min_len is not None:
             command_parts.append(f"-min {params.min_len}")
         if params.max_len is not None:

--- a/Snakefile
+++ b/Snakefile
@@ -33,6 +33,23 @@ in_dir = config.get("input_dir", "input")
 sup_dir = config.get("supplement_dir", "supplement")
 file_format = config.get("file_format","bed.gz")
 
+# Per-rule output subdirectories
+filter_file_dir                = os.path.join(out_dir, "filter_file")
+frag_length_bins_dir           = os.path.join(out_dir, "frag_length_bins")
+frag_length_intervals_dir      = os.path.join(out_dir, "frag_length_intervals")
+coverage_dir                   = os.path.join(out_dir, "coverage")
+end_motifs_dir                 = os.path.join(out_dir, "end_motifs")
+interval_end_motifs_dir        = os.path.join(out_dir, "interval_end_motifs")
+mds_dir                        = os.path.join(out_dir, "mds")
+interval_mds_dir               = os.path.join(out_dir, "interval_mds")
+wps_dir                        = os.path.join(out_dir, "wps")
+adjust_wps_dir                 = os.path.join(out_dir, "adjust_wps")
+delfi_dir                      = os.path.join(out_dir, "delfi")
+cleavage_profile_dir           = os.path.join(out_dir, "cleavage_profile")
+agg_bw_dir                     = os.path.join(out_dir, "agg_bw")
+breakpoint_motifs_dir          = os.path.join(out_dir, "breakpoint_motifs")
+interval_breakpoint_motifs_dir = os.path.join(out_dir, "interval_breakpoint_motifs")
+
 filter_file = config.get("filter_file", False)
 frag_length_bins = config.get("frag_length_bins", False)
 frag_length_intervals = config.get("frag_length_intervals", False)
@@ -86,30 +103,30 @@ sample_files = {
 rule all:
     input:
         # Output files for the filter-file.
-        io(["filtered.bed.gz","filtered.bed.gz.tbi"], sample_files['bed.gz'], file_format == "bed.gz"),
-        io(["filtered.frag.gz","filtered.frag.gz.tbi"], sample_files['frag.gz'], file_format == "frag.gz"),
-        io(["filtered.bam","filtered.bam.bai"], sample_files['bam'], file_format == "bam"),
-        io(["filtered.cram","filtered.cram.crai"], sample_files['cram'], file_format == "cram"),
+        io(["filtered.bed.gz","filtered.bed.gz.tbi"], sample_files['bed.gz'], file_format == "bed.gz", filter_file_dir),
+        io(["filtered.frag.gz","filtered.frag.gz.tbi"], sample_files['frag.gz'], file_format == "frag.gz", filter_file_dir),
+        io(["filtered.bam","filtered.bam.bai"], sample_files['bam'], file_format == "bam", filter_file_dir),
+        io(["filtered.cram","filtered.cram.crai"], sample_files['cram'], file_format == "cram", filter_file_dir),
 
         # Relevant output file if filtering out the mappability file.
         io(["filtered"], [config.get('interval_file', "")], exists('interval_file'), sup_dir),
-        
+
         # Relevant FinaleToolkit function output files.
         *[
-            io(["frag_length_bins.tsv", "frag_length_bins.png"], value, frag_length_bins) +
-            io(["frag_length_intervals.bed"], value, frag_length_intervals) +
-            io(["coverage.bed"], value, coverage) +
-            io(["end_motifs.tsv"], value, end_motifs) +
-            io(["interval_end_motifs.tsv"], value, interval_end_motifs) +
-            io(["mds.txt"], value, mds) +
-            io(["interval_mds.tsv"], value, interval_mds) +
-            io(["wps.bw"], value, wps) +
-            io(["adjust_wps.bw"], value, adjust_wps) +
-            io(["delfi.bed"], value, delfi) +
-            io(["cleavage_profile.bw"], value, cleavage_profile) +
-            io(["agg_bw.wig"], value, agg_bw) +
-            io(["breakpoint_motifs.tsv"], value, breakpoint_motifs) +
-            io(["interval_breakpoint_motifs.tsv"], value, interval_breakpoint_motifs)
+            io(["frag_length_bins.tsv", "frag_length_bins.png"], value, frag_length_bins, frag_length_bins_dir) +
+            io(["frag_length_intervals.bed"], value, frag_length_intervals, frag_length_intervals_dir) +
+            io(["coverage.bed"], value, coverage, coverage_dir) +
+            io(["end_motifs.tsv"], value, end_motifs, end_motifs_dir) +
+            io(["interval_end_motifs.tsv"], value, interval_end_motifs, interval_end_motifs_dir) +
+            io(["mds.txt"], value, mds, mds_dir) +
+            io(["interval_mds.tsv"], value, interval_mds, interval_mds_dir) +
+            io(["wps.bw"], value, wps, wps_dir) +
+            io(["adjust_wps.bw"], value, adjust_wps, adjust_wps_dir) +
+            io(["delfi.bed"], value, delfi, delfi_dir) +
+            io(["cleavage_profile.bw"], value, cleavage_profile, cleavage_profile_dir) +
+            io(["agg_bw.wig"], value, agg_bw, agg_bw_dir) +
+            io(["breakpoint_motifs.tsv"], value, breakpoint_motifs, breakpoint_motifs_dir) +
+            io(["interval_breakpoint_motifs.tsv"], value, interval_breakpoint_motifs, interval_breakpoint_motifs_dir)
             for key, value in sample_files.items() if key == file_format
         ]
 
@@ -120,8 +137,8 @@ rule filter_file:
         main=os.path.join(in_dir, "{sample}.") + file_format,
         index=os.path.join(in_dir, "{sample}.") + file_format + "." + index
     output:
-        main=os.path.join(out_dir, "{sample}.filtered.") + file_format,
-        index=os.path.join(out_dir, "{sample}.filtered.") + file_format + "." + index,
+        main=os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
+        index=os.path.join(filter_file_dir, "{sample}.filtered.") + file_format + "." + index,
     params:
         filter_file_mapq = config.get("filter_file_mapq", 0),
         filter_file_min_length = config.get("filter_file_min_length", 0),
@@ -157,10 +174,10 @@ rule filter_interval_file:
 # STEP 4: Regular Finaletoolkit commands.
 rule frag_length_bins:
     input:
-        os.path.join(out_dir, "{sample}.filtered.") + file_format
+        os.path.join(filter_file_dir, "{sample}.filtered.") + file_format
     output:
-        tsv=os.path.join(out_dir, "{sample}.frag_length_bins.tsv"),
-        png=os.path.join(out_dir, "{sample}.frag_length_bins.png")
+        tsv=os.path.join(frag_length_bins_dir, "{sample}.frag_length_bins.tsv"),
+        png=os.path.join(frag_length_bins_dir, "{sample}.frag_length_bins.png")
     threads: 1
     params:
         mapq = config.get("frag_length_bins_mapq"),
@@ -203,10 +220,10 @@ rule frag_length_bins:
 
 rule frag_length_intervals:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}" + ".filtered")
     output:
-        os.path.join(out_dir, "{sample}.frag_length_intervals.bed")
+        os.path.join(frag_length_intervals_dir, "{sample}.frag_length_intervals.bed")
     threads: config.get("frag_length_intervals_workers")
     params:
         min_len = config.get("frag_length_intervals_min_len"),
@@ -245,10 +262,10 @@ rule frag_length_intervals:
 
 rule coverage:
     input:
-        data= os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data= os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}" + ".filtered")
     output:
-        os.path.join(out_dir, "{sample}.coverage.bed")
+        os.path.join(coverage_dir, "{sample}.coverage.bed")
     threads: config.get("coverage_workers")
     params:
         min_len = config.get("coverage_min_len"),
@@ -293,10 +310,10 @@ rule coverage:
 
 rule end_motifs:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         refseq = os.path.join(sup_dir, f"{config.get('end_motifs_refseq_file')}")
     output:
-        os.path.join(out_dir, "{sample}.end_motifs.tsv")
+        os.path.join(end_motifs_dir, "{sample}.end_motifs.tsv")
     threads: config.get("end_motifs_workers")
     params:
         kmer_length = config.get("end_motifs_kmer_length"),
@@ -338,11 +355,11 @@ rule end_motifs:
 
 rule interval_end_motifs:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         refseq = os.path.join(sup_dir, f"{config.get('interval_end_motifs_refseq_file')}"),
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}.filtered")
     output:
-        os.path.join(out_dir, "{sample}.interval_end_motifs.tsv")
+        os.path.join(interval_end_motifs_dir, "{sample}.interval_end_motifs.tsv")
     threads: config.get("interval_end_motifs_workers")
     params:
         kmer_length = config.get("interval_end_motifs_kmer_length"),
@@ -385,9 +402,9 @@ rule interval_end_motifs:
 
 rule mds:
     input:
-        os.path.join(out_dir, "{sample}.end_motifs.tsv")
+        os.path.join(end_motifs_dir, "{sample}.end_motifs.tsv")
     output:
-        os.path.join(out_dir, "{sample}.mds.txt")
+        os.path.join(mds_dir, "{sample}.mds.txt")
     params:
         sep = config.get("mds_sep", " "),
         header = config.get("mds_header")
@@ -409,9 +426,9 @@ rule mds:
 
 rule interval_mds:
     input:
-        os.path.join(out_dir, "{sample}.interval_end_motifs.tsv")
+        os.path.join(interval_end_motifs_dir, "{sample}.interval_end_motifs.tsv")
     output:
-        os.path.join(out_dir, "{sample}.interval_mds.tsv")
+        os.path.join(interval_mds_dir, "{sample}.interval_mds.tsv")
     params:
         sep = config.get("interval_mds_sep", " "),
         header = config.get("interval_mds_header")
@@ -433,10 +450,10 @@ rule interval_mds:
 
 rule wps:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         site_bed = os.path.join(sup_dir, f"{config.get('wps_site_bed')}")
     output:
-        os.path.join(out_dir, "{sample}.wps.bw")
+        os.path.join(wps_dir, "{sample}.wps.bw")
     threads: config.get("wps_workers")
     params:
         chrom_sizes = config.get("wps_chrom_sizes"),
@@ -469,11 +486,11 @@ rule wps:
 
 rule adjust_wps:
     input:
-        wps = os.path.join(out_dir, "{sample}.wps.bw"),
+        wps = os.path.join(wps_dir, "{sample}.wps.bw"),
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}" + ".filtered"),
         chrom_sizes = os.path.join(sup_dir, f"{config.get('adjust_wps_chrom_sizes')}")
     output:
-        os.path.join(out_dir, "{sample}.adjust_wps.bw")
+        os.path.join(adjust_wps_dir, "{sample}.adjust_wps.bw")
     threads: config.get("adjust_wps_workers")
     params:
         interval_size = config.get("adjust_wps_interval_size"),
@@ -519,12 +536,12 @@ rule adjust_wps:
 
 rule delfi:
     input:
-        input_file = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        input_file = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         chrom_sizes = os.path.join(sup_dir, f"{config.get('delfi_chrom_sizes')}"),
         reference_file = os.path.join(sup_dir, f"{config.get('delfi_reference_file')}"),
         bins_file = os.path.join(sup_dir, f"{config.get('delfi_bins_file')}")
     output:
-        os.path.join(out_dir, "{sample}.delfi.bed")
+        os.path.join(delfi_dir, "{sample}.delfi.bed")
     threads: config.get("delfi_workers")
     params:
         blacklist_file = config.get("delfi_blacklist_file"),
@@ -578,11 +595,11 @@ rule delfi:
 
 rule cleavage_profile:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}.filtered"),
         chrom_sizes = os.path.join(sup_dir, f"{config.get('cleavage_profile_chrom_sizes')}")
     output:
-        os.path.join(out_dir, "{sample}.cleavage_profile.bw")
+        os.path.join(cleavage_profile_dir, "{sample}.cleavage_profile.bw")
     threads: config.get("cleavage_profile_workers")
     params:
         min_len = config.get("cleavage_profile_min_len"),
@@ -620,10 +637,10 @@ rule cleavage_profile:
 
 rule agg_bw:
     input:
-        data = os.path.join(out_dir, "{sample}.cleavage_profile.bw"),
+        data = os.path.join(cleavage_profile_dir, "{sample}.cleavage_profile.bw"),
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}.filtered")
     output:
-        os.path.join(out_dir, "{sample}.agg_bw.wig")
+        os.path.join(agg_bw_dir, "{sample}.agg_bw.wig")
     threads: 1
     params:
         median_window_size = config.get("agg_bw_median_window_size"),
@@ -650,10 +667,10 @@ rule agg_bw:
 
 rule breakpoint_motifs:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         refseq = os.path.join(sup_dir, f"{config.get('breakpoint_motifs_refseq_file')}")
     output:
-        os.path.join(out_dir, "{sample}.breakpoint_motifs.tsv")
+        os.path.join(breakpoint_motifs_dir, "{sample}.breakpoint_motifs.tsv")
     threads: config.get("breakpoint_motifs_workers")
     params:
         kmer_length = config.get("breakpoint_motifs_kmer_length"),
@@ -695,11 +712,11 @@ rule breakpoint_motifs:
 
 rule interval_breakpoint_motifs:
     input:
-        data = os.path.join(out_dir, "{sample}.filtered.") + file_format,
+        data = os.path.join(filter_file_dir, "{sample}.filtered.") + file_format,
         refseq = os.path.join(sup_dir, f"{config.get('interval_breakpoint_motifs_refseq_file')}"),
         intervals = os.path.join(sup_dir, f"{config.get('interval_file')}.filtered")
     output:
-        os.path.join(out_dir, "{sample}.interval_breakpoint_motifs.tsv")
+        os.path.join(interval_breakpoint_motifs_dir, "{sample}.interval_breakpoint_motifs.tsv")
     threads: config.get("interval_breakpoint_motifs_workers")
     params:
         kmer_length = config.get("interval_breakpoint_motifs_kmer_length"),

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,4 @@ dependencies:
   - htslib==1.21
   - samtools==1.21
   - snakemake==8.26.0
-  - finaletoolkit==0.11.0
+  - finaletoolkit==1.0.0

--- a/params.yaml
+++ b/params.yaml
@@ -1,10 +1,13 @@
 # Below is a sample configuration for extracting coverage features
+# Config keys follow FinaleToolkit 1.0.0 terminology (see the README migration note).
 
 # input_dir: "input_data"
 # output_dir: "output_data"
-# supplement_dir: "supplement" 
+# supplement_dir: "supplement"
 # interval_file: "intervals.bins"
 # file_format: "bed.gz"
+
+# threads: 1  # Global worker count used by the filter-file step
 
 # Finaletoolkit filter-file parameters
 
@@ -15,7 +18,6 @@
 # filter_file_blacklist_file: "blacklist.bed"
 # filter_file_whitelist_file: "whitelist.bed"
 # filter_file_intersect_policy: "midpoint"
-# filter_file_workers: 1
 
 # Mappability parameters
 
@@ -27,31 +29,31 @@
 # frag_length_bins_bin_size: 10
 # frag_length_bins_mapq: 30
 # frag_length_bins_policy: "midpoint"
-# frag_length_bins_min_len: 50
-# frag_length_bins_max_len: 350
+# frag_length_bins_min_length: 50
+# frag_length_bins_max_length: 350
 # frag_length_bins_chrom: "22"
 # frag_length_bins_start: 0
 # frag_length_bins_end: 41000000
 # frag_length_bins_summary_stats: True
-# frag_length_bins_short_fraction: 150
+# frag_length_bins_short_threshold: 150
 # frag_length_bins_reference_file: "ref.fa"  # Required for CRAM input
 
 # Frag-length-intervals parameters
 # frag_length_intervals: True
 # frag_length_intervals_mapq: 30
 # frag_length_intervals_policy: "midpoint"
-# frag_length_intervals_min_len: 50
-# frag_length_intervals_max_len: 350
-# frag_length_intervals_workers: 1
-# frag_length_intervals_short_reads: 150
+# frag_length_intervals_min_length: 50
+# frag_length_intervals_max_length: 350
+# frag_length_intervals_threads: 1
+# frag_length_intervals_short_threshold: 150
 # frag_length_intervals_reference_file: "ref.fa"  # Required for CRAM input
 
 # coverage: True
 # coverage_mapq: 30
 # coverage_intersect_policy: "any"
-# coverage_min_len: 50
-# coverage_max_len: 350
-# coverage_workers: 1
+# coverage_min_length: 50
+# coverage_max_length: 350
+# coverage_threads: 1
 # coverage_normalize: True
 # coverage_scale_factor: 1000000
 # coverage_reference_file: "ref.fa"  # Required for CRAM input
@@ -59,40 +61,38 @@
 # end_motifs: True
 # end_motifs_refseq_file: "ref.fa"  # A .2bit or FASTA (.fa, .fasta, .fna) file
 # end_motifs_kmer_length: 5
-# end_motifs_min_len: 50
-# end_motifs_max_len: 350
-# end_motifs_single_strand: True  # When True, only considers one strand (-B flag)
-# end_motifs_negative_strand: False  # When True (requires single_strand: True), uses negative strand
+# end_motifs_min_length: 50
+# end_motifs_max_length: 350
+# end_motifs_strand: "both"  # both | forward | reverse (default both). Replaces single_strand/negative_strand.
 # end_motifs_mapq: 30
-# end_motifs_workers: 1
+# end_motifs_threads: 1
 
 # interval_end_motifs: True
 # interval_end_motifs_refseq_file: "ref.2bit"
 # interval_end_motifs_kmer_length: 4
-# interval_end_motifs_min_len: 50
-# interval_end_motifs_max_len: 350
-# interval_end_motifs_single_strand: False
-# interval_end_motifs_negative_strand: False
+# interval_end_motifs_min_length: 50
+# interval_end_motifs_max_length: 350
+# interval_end_motifs_strand: "both"  # both | forward | reverse (default both)
 # interval_end_motifs_mapq: 30
-# interval_end_motifs_workers: 1
+# interval_end_motifs_threads: 1
 
 # mds: True
 # mds_sep: " "
 # mds_header: 0
 
-# interval_mds: True
-# interval_mds_sep: " "
-# interval_mds_header: 0
+# regional_mds: True  # Regional MDS (rMDS); renamed from interval-mds in 1.0.0
+# regional_mds_sep: " "
+# regional_mds_header: 0
 
 # wps: True
 # wps_chrom_sizes: "ref.chrom.sizes"
 # wps_site_bed: "sites.bed"
 # wps_interval_size: 5000
 # wps_window_size: 120
-# wps_min_len: 120
-# wps_max_len: 180
+# wps_min_length: 120
+# wps_max_length: 180
 # wps_mapq: 30
-# wps_workers: 4
+# wps_threads: 4
 # wps_reference_file: "ref.fa"  # Required for CRAM input
 
 # adjust_wps: True
@@ -102,8 +102,8 @@
 # adjust_wps_median_window_size: 200
 # adjust_wps_savgol_window_size: 21
 # adjust_wps_savgol_poly_deg: 2
-# adjust_wps_exclude_savgol: True
-# adjust_wps_workers: 4
+# adjust_wps_savgol: True  # Apply Savitzky-Golay filtering (on by default). Set False to disable (--no-savgol).
+# adjust_wps_threads: 4
 # adjust_wps_mean: False
 # adjust_wps_subtract_edges: True
 # adjust_wps_edge_size: 500 # Breaks functionality for some reason
@@ -116,20 +116,20 @@
 # delfi_reference_file: "ref.2bit"
 # delfi_bins_file: "interval.bins"
 # delfi_no_gc_correct: False
-# delfi_keep_nocov: False
-# delfi_no_merge_bins: True
-# delfi_window_size: 5000000
+# delfi_remove_nocov: True  # Remove the two hg19 no-coverage bins (on by default). Set False for non-hg19 references (--no-remove-nocov).
+# delfi_merge_bins: True    # Merge input bins to 5Mb (on by default). Set False to keep input bins (--no-merge-bins).
+# delfi_merge_size: 5000000
 # delfi_mapq: 30
-# delfi_workers: 4
+# delfi_threads: 4
 
 # cleavage_profile: True
 # cleavage_profile_chrom_sizes: "ref.chrom.sizes"
-# cleavage_profile_min_len: 50
-# cleavage_profile_max_len: 350
+# cleavage_profile_min_length: 50
+# cleavage_profile_max_length: 350
 # cleavage_profile_mapq: 30
-# cleavage_profile_left: 2000
-# cleavage_profile_right: 2000
-# cleavage_profile_workers: 8
+# cleavage_profile_pad_left: 2000
+# cleavage_profile_pad_right: 2000
+# cleavage_profile_threads: 8
 # cleavage_profile_reference_file: "ref.fa"  # Required for CRAM input
 
 # agg_bw: True
@@ -139,19 +139,17 @@
 # breakpoint_motifs: True
 # breakpoint_motifs_refseq_file: "ref.fa"  # A .2bit or FASTA (.fa, .fasta, .fna) file
 # breakpoint_motifs_kmer_length: 4
-# breakpoint_motifs_min_len: 50
-# breakpoint_motifs_max_len: 350
-# breakpoint_motifs_single_strand: False
-# breakpoint_motifs_negative_strand: False
+# breakpoint_motifs_min_length: 50
+# breakpoint_motifs_max_length: 350
+# breakpoint_motifs_strand: "both"  # both | forward | reverse (default both)
 # breakpoint_motifs_mapq: 30
-# breakpoint_motifs_workers: 1
+# breakpoint_motifs_threads: 1
 
 # interval_breakpoint_motifs: True
 # interval_breakpoint_motifs_refseq_file: "ref.fa"  # A .2bit or FASTA (.fa, .fasta, .fna) file
 # interval_breakpoint_motifs_kmer_length: 4
-# interval_breakpoint_motifs_min_len: 50
-# interval_breakpoint_motifs_max_len: 350
-# interval_breakpoint_motifs_single_strand: False
-# interval_breakpoint_motifs_negative_strand: False
+# interval_breakpoint_motifs_min_length: 50
+# interval_breakpoint_motifs_max_length: 350
+# interval_breakpoint_motifs_strand: "both"  # both | forward | reverse (default both)
 # interval_breakpoint_motifs_mapq: 30
-# interval_breakpoint_motifs_workers: 1
+# interval_breakpoint_motifs_threads: 1

--- a/params.yaml
+++ b/params.yaml
@@ -32,6 +32,9 @@
 # frag_length_bins_chrom: "22"
 # frag_length_bins_start: 0
 # frag_length_bins_end: 41000000
+# frag_length_bins_summary_stats: True
+# frag_length_bins_short_fraction: 150
+# frag_length_bins_reference_file: "ref.fa"  # Required for CRAM input
 
 # Frag-length-intervals parameters
 # frag_length_intervals: True
@@ -40,6 +43,8 @@
 # frag_length_intervals_min_len: 50
 # frag_length_intervals_max_len: 350
 # frag_length_intervals_workers: 1
+# frag_length_intervals_short_reads: 150
+# frag_length_intervals_reference_file: "ref.fa"  # Required for CRAM input
 
 # coverage: True
 # coverage_mapq: 30
@@ -49,13 +54,15 @@
 # coverage_workers: 1
 # coverage_normalize: True
 # coverage_scale_factor: 1000000
+# coverage_reference_file: "ref.fa"  # Required for CRAM input
 
 # end_motifs: True
+# end_motifs_refseq_file: "ref.fa"  # A .2bit or FASTA (.fa, .fasta, .fna) file
 # end_motifs_kmer_length: 5
 # end_motifs_min_len: 50
 # end_motifs_max_len: 350
-# end_motifs_no_both_strands: True
-# end_motifs_negative_strand: False
+# end_motifs_single_strand: True  # When True, only considers one strand (-B flag)
+# end_motifs_negative_strand: False  # When True (requires single_strand: True), uses negative strand
 # end_motifs_mapq: 30
 # end_motifs_workers: 1
 
@@ -86,6 +93,7 @@
 # wps_max_len: 180
 # wps_mapq: 30
 # wps_workers: 4
+# wps_reference_file: "ref.fa"  # Required for CRAM input
 
 # adjust_wps: True
 # adjust_wps_interval_file: "sites.bed"
@@ -122,7 +130,28 @@
 # cleavage_profile_left: 2000
 # cleavage_profile_right: 2000
 # cleavage_profile_workers: 8
+# cleavage_profile_reference_file: "ref.fa"  # Required for CRAM input
 
 # agg_bw: True
 # agg_bw_median_window_size: 1
 # agg_bw_mean: True
+
+# breakpoint_motifs: True
+# breakpoint_motifs_refseq_file: "ref.fa"  # A .2bit or FASTA (.fa, .fasta, .fna) file
+# breakpoint_motifs_kmer_length: 4
+# breakpoint_motifs_min_len: 50
+# breakpoint_motifs_max_len: 350
+# breakpoint_motifs_single_strand: False
+# breakpoint_motifs_negative_strand: False
+# breakpoint_motifs_mapq: 30
+# breakpoint_motifs_workers: 1
+
+# interval_breakpoint_motifs: True
+# interval_breakpoint_motifs_refseq_file: "ref.fa"  # A .2bit or FASTA (.fa, .fasta, .fna) file
+# interval_breakpoint_motifs_kmer_length: 4
+# interval_breakpoint_motifs_min_len: 50
+# interval_breakpoint_motifs_max_len: 350
+# interval_breakpoint_motifs_single_strand: False
+# interval_breakpoint_motifs_negative_strand: False
+# interval_breakpoint_motifs_mapq: 30
+# interval_breakpoint_motifs_workers: 1


### PR DESCRIPTION
## Summary

FinaleToolkit 1.0.0 reimplemented its CLI on Click and **intentionally redesigned every flag** for consistency (the one deliberate break; the Python API is unchanged). This PR migrates every `finaletoolkit` invocation in the Snakefile to the 1.0.0 CLI and adopts the new terminology in the workflow's own `params.yaml` config keys, rule names, and output dirs.

Ground truth for each flag was taken from the 1.0.0 source (`cli/_args.py`, `cli/commands/__init__.py`).

## Changes

**CLI flags (Snakefile)**
- `-w`→`-t` (workers→threads); `-min`/`-max`→`--min-length`/`--max-length`
- Motif `-B`/`-n` booleans → `--strand {both,forward,reverse}`
- coverage `-s`→`--scale-factor`; wps `-c`→`--chrom-sizes`
- adjust-wps `-s`/`-p`/`-S`→`--savgol-window-size`/`--savgol-poly-deg`/`--no-savgol`
- delfi `-G`/`-R`/`-M`/`-s`→`--no-gc-correct`/`--no-remove-nocov`/`--no-merge-bins`/`--merge-size`
- cleavage-profile `-l`/`-r`/`--reference-file`→`--pad-left`/`--pad-right`/`--reference`
- agg-bw `-a`→`--mean`; filter-file `-W`/`-B`→`-w`/`-b`
- `mds` now writes to **stdout** (redirected to the output file)
- `interval-mds` → **`regional-mds`** (rule, config keys, output dir, and `*.regional_mds.tsv` filename)

**Workflow config keys (breaking for existing `params.yaml`)**
- `_workers`→`_threads`, `_min_len`/`_max_len`→`_min_length`/`_max_length`, motif `_single_strand`+`_negative_strand`→`_strand`, `cleavage_profile_left`/`right`→`_pad_left`/`_pad_right`, `delfi_window_size`→`delfi_merge_size`, `short_fraction`/`short_reads`→`short_threshold`, inverted booleans `adjust_wps_savgol`/`delfi_remove_nocov`/`delfi_merge_bins`, `interval_mds`→`regional_mds`. A migration table is included in the README.

**Other**
- Fix a pre-existing `filter_file` whitelist/blacklist key mismatch (rule now reads the documented `filter_file_{whitelist,blacklist}_file` keys).
- Bump `environment.yml` pin to `finaletoolkit==1.0.0`.
- Ignore `.DS_Store`.

## Verification

Verified against a real `finaletoolkit==1.0.0` install:
- All 16 subcommands' flags validated against the real `--help`; old flags/subcommands (`-min`, `-w`, `-W`, `-l`, delfi `-s`, `mds a b`, `interval-mds`) confirmed rejected.
- Behavioral changes exercised for real: `mds` stdout-redirect and `regional-mds` positional output.
- Real Snakefile run on FinaleToolkit test fragment data: `filter-file` → `frag-length-bins` + `coverage` + `frag-length-intervals` completed successfully, with new flags reflected in outputs (`s150` short-fraction column, `--scale-factor`/`--normalize` coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)